### PR TITLE
Check paypal vaulted methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree Android Drop-In Release Notes
 
+## 4.4.2 
+* Checked whether PayPal is enabled in DropInRequest also for vaulted payment methods. 
+
 ## 4.4.1 
 * Fix bug in `AddCardActivity#onError` that prevented passing error cases up to the appropriate listeners.
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -7,7 +7,7 @@ def LOCALHOST_IP = System.properties['LOCALHOST_IP'] ?: '"10.0.2.2"';
 def GATEWAY_IP = System.properties['GATEWAY_IP'] ?: '"10.0.2.2"';
 def GATEWAY_PORT = System.properties['GATEWAY_PORT'] ?: '"3000"';
 
-version '4.4.1'
+version '4.4.2'
 
 android {
     compileSdkVersion 28
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 82
+        versionCode 83
         versionName version
 
         consumerProguardFiles 'proguard.pro'

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -1,4 +1,10 @@
+plugins {
+    id "com.jfrog.artifactory" version "4.9.10"
+}
+
 apply plugin: 'com.android.library'
+apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'maven-publish'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'io.codearte.nexus-staging'
@@ -179,6 +185,35 @@ uploadArchives {
                     }
                 }
             }
+        }
+    }
+}
+
+publishing {
+    publications {
+        aar(MavenPublication) {
+            groupId 'com.braintreepayments.api'
+            artifactId 'drop-in'
+            version = '4.4.2'
+            artifact("$buildDir/outputs/aar/Drop-In-release.aar")
+        }
+    }
+}
+
+artifactory {
+    publish {
+        contextUrl = System.getenv("ARTIFACTORY_CONTEXT")
+        repository {
+            repoKey = 'libs-release-local'
+            username = System.getenv("ARTIFACTORY_USER")
+            password = System.getenv("ARTIFACTORY_PWD")
+        }
+        defaults {
+            publications('aar')
+            publishArtifacts = true
+            publishBuildInfo = false
+            publishPom = true
+            publishIvy = false
         }
     }
 }

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -41,6 +41,7 @@ import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNoncesUpdatedListener;
 import com.braintreepayments.api.models.CardNonce;
 import com.braintreepayments.api.models.Configuration;
+import com.braintreepayments.api.models.PayPalAccountNonce;
 import com.braintreepayments.api.models.PayPalRequest;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 import com.braintreepayments.api.models.ThreeDSecureRequest;
@@ -280,6 +281,15 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
 
     @Override
     public void onPaymentMethodNoncesUpdated(List<PaymentMethodNonce> paymentMethodNonces) {
+
+        if (!mDropInRequest.isPayPalEnabled()) {
+            for (int i = paymentMethodNonces.size() - 1; i >= 0; i --) {
+                if (paymentMethodNonces.get(i) instanceof PayPalAccountNonce) {
+                    paymentMethodNonces.remove(i);
+                }
+            }
+        }
+
         if (paymentMethodNonces.size() > 0) {
             mSupportedPaymentMethodsHeader.setText(R.string.bt_other);
             mVaultedPaymentMethodsContainer.setVisibility(View.VISIBLE);


### PR DESCRIPTION
### Summary of changes
Since the `disablePaypal()` from `DropInRequest` disables the possibility to add a **new** PayPal payment method, but does not disables **vaulted** PayPal payment methods, so with this PR I'm filtering those.

This PR also adds the logic to deploy to Artifactory the built **aar**, to enable the usage via Gradle.

### Authors
@davideavagliano 
